### PR TITLE
refactor(fga): use BuildContextualTuples from golang-commons/fga/model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/oapi-codegen/runtime v1.3.1
 	github.com/openfga/api/proto v0.0.0-20260319214821-f153694bfc20
 	github.com/platform-mesh/account-operator v0.12.32
-	github.com/platform-mesh/golang-commons v0.13.23
+	github.com/platform-mesh/golang-commons v0.14.0
 	github.com/platform-mesh/security-operator v0.27.15
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/platform-mesh/account-operator v0.12.32 h1:ByOCF8vpTxS48nVhAyNq/ZLt3x
 github.com/platform-mesh/account-operator v0.12.32/go.mod h1:ChaYprfmiy16A4+y59ldJKv8AdLF2ZCuWqodIFVcrgI=
 github.com/platform-mesh/golang-commons v0.13.23 h1:doW/IMkY7iNNzlyI6QHlo2uSXZnbvddmRp6Cgf6pIK8=
 github.com/platform-mesh/golang-commons v0.13.23/go.mod h1:V4Db8FH1Uxpevz+dKrLBHFGqP2XvxYXXfCfF0xqngx0=
+github.com/platform-mesh/golang-commons v0.14.0 h1:QZldFRL84Ka2ZiEtkTkaXjn6NGvGyxyYAdepMhnrMJU=
+github.com/platform-mesh/golang-commons v0.14.0/go.mod h1:V4Db8FH1Uxpevz+dKrLBHFGqP2XvxYXXfCfF0xqngx0=
 github.com/platform-mesh/security-operator v0.27.15 h1:XFmJwtbjgUhGMJ2aanuGjyqsEcz+ob8VDKgZl1NYHPs=
 github.com/platform-mesh/security-operator v0.27.15/go.mod h1:uDDRHHkQ6DG4isEsbU8DaO79t5IPVwmvCAHdkGvUFPU=
 github.com/platform-mesh/subroutines v0.2.6 h1:/xIN/4Z015M9qh7HUuLkxX5mXv2xpFa5l6esknKGxa8=

--- a/pkg/fga/tuples/tuples.go
+++ b/pkg/fga/tuples/tuples.go
@@ -6,53 +6,49 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	accountsv1alpha1 "github.com/platform-mesh/account-operator/api/v1alpha1"
-	"github.com/platform-mesh/golang-commons/fga/util"
+	fgamodel "github.com/platform-mesh/golang-commons/fga/model"
 
 	"github.com/platform-mesh/iam-service/pkg/graph"
 )
 
 func GenerateContextualTuples(rctx *graph.ResourceContext, ai *accountsv1alpha1.AccountInfo) *openfgav1.ContextualTupleKeys {
-	tuples := &openfgav1.ContextualTupleKeys{}
+	accountObject := fmt.Sprintf("%s:%s/%s",
+		fgamodel.BuildObjectType("core.platform-mesh.io", "account"),
+		ai.Spec.Account.OriginClusterId,
+		ai.Spec.Account.Name,
+	)
 
-	accFGATypeName := util.ConvertToTypeName("core.platform-mesh.io", "Account")
-	accObject := fmt.Sprintf("%s:%s/%s", accFGATypeName, ai.Spec.Account.OriginClusterId, ai.Spec.Account.Name)
-
-	var nsObject string
+	var namespace string
 	if rctx.Resource.Namespace != nil {
-		nsFGATypeName := util.ConvertToTypeName("", "Namespace")
-		nsObject = fmt.Sprintf("%s:%s/%s", nsFGATypeName, ai.Spec.Account.GeneratedClusterId, *rctx.Resource.Namespace)
-
-		// Add namespace contextual tuple
-		namespaceTuple := &openfgav1.TupleKey{
-			Object:   nsObject,
-			Relation: "parent",
-			User:     accObject,
-		}
-		tuples.TupleKeys = append(tuples.TupleKeys, namespaceTuple)
+		namespace = *rctx.Resource.Namespace
 	}
 
-	if !managedTuple(rctx.Group, rctx.Kind) {
-		resFGATypeName := util.ConvertToTypeName(rctx.Group, rctx.Kind)
-		var resObject string
-		if rctx.Resource.Namespace != nil {
-			resObject = fmt.Sprintf("%s:%s/%s/%s", resFGATypeName, ai.Spec.Account.GeneratedClusterId, *rctx.Resource.Namespace, rctx.Resource.Name)
-		} else {
-			resObject = fmt.Sprintf("%s:%s/%s", resFGATypeName, ai.Spec.Account.GeneratedClusterId, rctx.Resource.Name)
+	// Skip the resource tuple for managed types (e.g. core.platform-mesh.io/Account);
+	// they are their own FGA identity and only need the namespace tuple (if namespaced).
+	if managedTuple(rctx.Group, rctx.Kind) {
+		if namespace == "" {
+			return &openfgav1.ContextualTupleKeys{}
 		}
-
-		resTuple := &openfgav1.TupleKey{
-			Object:   resObject,
-			Relation: "parent",
+		nsObj := fgamodel.BuildObjectName("", "namespace", ai.Spec.Account.GeneratedClusterId, namespace, nil)
+		return &openfgav1.ContextualTupleKeys{
+			TupleKeys: []*openfgav1.TupleKey{
+				{Object: nsObj, Relation: "parent", User: accountObject},
+			},
 		}
-		if rctx.Resource.Namespace != nil {
-			resTuple.User = nsObject
-		} else {
-			resTuple.User = accObject
-		}
-		tuples.TupleKeys = append(tuples.TupleKeys, resTuple)
 	}
 
-	return tuples
+	tupleKeys, err := fgamodel.BuildContextualTuples(accountObject, fgamodel.ResourceContext{
+		Group:     rctx.Group,
+		Kind:      strings.ToLower(rctx.Kind),
+		ClusterID: ai.Spec.Account.GeneratedClusterId,
+		Name:      rctx.Resource.Name,
+		Namespace: namespace,
+	})
+	if err != nil {
+		return &openfgav1.ContextualTupleKeys{}
+	}
+
+	return &openfgav1.ContextualTupleKeys{TupleKeys: tupleKeys}
 }
 
 func managedTuple(group, kind string) bool {

--- a/pkg/fga/tuples/tuples.go
+++ b/pkg/fga/tuples/tuples.go
@@ -1,7 +1,6 @@
 package tuples
 
 import (
-	"fmt"
 	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -12,16 +11,18 @@ import (
 )
 
 func GenerateContextualTuples(rctx *graph.ResourceContext, ai *accountsv1alpha1.AccountInfo) *openfgav1.ContextualTupleKeys {
-	accountObject := fmt.Sprintf("%s:%s/%s",
-		fgamodel.BuildObjectType("core.platform-mesh.io", "account"),
-		ai.Spec.Account.OriginClusterId,
-		ai.Spec.Account.Name,
-	)
-
 	var namespace string
 	if rctx.Resource.Namespace != nil {
 		namespace = *rctx.Resource.Namespace
 	}
+
+	accountObject := fgamodel.BuildObjectName(
+		"core.platform-mesh.io",
+		"account",
+		ai.Spec.Account.GeneratedClusterId,
+		ai.Spec.Account.Name,
+		&namespace,
+	)
 
 	// Skip the resource tuple for managed types (e.g. core.platform-mesh.io/Account);
 	// they are their own FGA identity and only need the namespace tuple (if namespaced).


### PR DESCRIPTION
This change re-uses the BuildContextualTuples that was oursourced to golang-commons in [#203](https://github.com/platform-mesh/golang-commons/pull/203).

On-behalf-of: @SAP florian.wuermseer@sap.com