### PR TITLE
test: add parser fuzz tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -67,6 +67,14 @@ tasks:
   test:
     deps:
       - task: unittest
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./pkg/directive/ -run=^$ -fuzz=FuzzExtractResourceContext -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./pkg/sorter/ -run=^$ -fuzz=FuzzParseUserSortField -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./pkg/sorter/ -run=^$ -fuzz=FuzzParseSortDirection -fuzztime={{.FUZZTIME}} -count=1
   validate:
     cmds:
       - task: fmt

--- a/pkg/directive/authorized_fuzz_test.go
+++ b/pkg/directive/authorized_fuzz_test.go
@@ -1,0 +1,28 @@
+package directive
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzExtractResourceContext(f *testing.F) {
+	f.Add(`{"context":{"group":"core.platform-mesh.io","kind":"Account","resource":{"name":"test"},"accountPath":"root:org"}}`)
+	f.Add(`{"context":{"group":"","kind":"","resource":{"name":"","namespace":"ns"},"accountPath":""}}`)
+	f.Add(`{"context":{}}`)
+	f.Add(`{}`)
+	f.Add(`{"context":"not-an-object"}`)
+	f.Add(`{"wrongKey":true}`)
+	f.Add(`not json`)
+	f.Add(``)
+	f.Add(`null`)
+	f.Add(`{"context":null}`)
+
+	f.Fuzz(func(t *testing.T, input string) {
+		var args map[string]any
+		if err := json.Unmarshal([]byte(input), &args); err != nil {
+			return
+		}
+		// Must not panic regardless of map contents.
+		_, _ = extractResourceContextFromArguments(args)
+	})
+}

--- a/pkg/sorter/user_sorter_fuzz_test.go
+++ b/pkg/sorter/user_sorter_fuzz_test.go
@@ -1,0 +1,33 @@
+package sorter
+
+import (
+	"testing"
+)
+
+func FuzzParseUserSortField(f *testing.F) {
+	f.Add("lastName")
+	f.Add("last_name")
+	f.Add("USERID")
+	f.Add("email")
+	f.Add("firstName")
+	f.Add("")
+	f.Add("unknown_field")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_ = parseUserSortField(input)
+	})
+}
+
+func FuzzParseSortDirection(f *testing.F) {
+	f.Add("ASC")
+	f.Add("DESC")
+	f.Add("asc")
+	f.Add("ASCENDING")
+	f.Add("DESCENDING")
+	f.Add("")
+	f.Add("invalid")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		_ = parseSortDirection(input)
+	})
+}


### PR DESCRIPTION
## Summary
- Add fuzz test for `extractResourceContextFromArguments` in `pkg/directive` to verify it never panics on arbitrary JSON input
- Add fuzz tests for `parseUserSortField` and `parseSortDirection` in `pkg/sorter` to verify enum parsing handles arbitrary strings safely
- Add `task fuzz` entry to Taskfile for on-demand fuzzing with configurable duration

Closes #452
Part of platform-mesh/backlog#231