### PR TITLE
Added Prometheus custom metrics to iam-service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/platform-mesh/account-operator v0.14.30
 	github.com/platform-mesh/golang-commons v0.16.12
 	github.com/platform-mesh/security-operator v0.30.56
+	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -62,12 +63,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.31.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/platform-mesh/subroutines v0.3.3 // indirect
 	github.com/pquerna/cachecontrol v0.2.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/pkg/directive/authorized.go
+++ b/pkg/directive/authorized.go
@@ -24,6 +24,7 @@ import (
 	"github.com/platform-mesh/iam-service/pkg/fga/store"
 	"github.com/platform-mesh/iam-service/pkg/fga/tuples"
 	"github.com/platform-mesh/iam-service/pkg/graph"
+	"github.com/platform-mesh/iam-service/pkg/metrics"
 	"github.com/platform-mesh/iam-service/pkg/workspace"
 )
 
@@ -132,6 +133,10 @@ func (a AuthorizedDirective) Authorized(ctx context.Context, _ any, next graphql
 }
 
 func (a AuthorizedDirective) testIfAllowed(ctx context.Context, ai *accountsv1alpha1.AccountInfo, rctx *graph.ResourceContext, permission string, token jwt.WebToken) (bool, error) {
+	start := time.Now()
+	defer func() {
+		metrics.AuthorizationDuration.WithLabelValues(permission).Observe(time.Since(start).Seconds())
+	}()
 
 	ct := tuples.GenerateContextualTuples(rctx, ai)
 
@@ -165,7 +170,14 @@ func (a AuthorizedDirective) testIfAllowed(ctx context.Context, ai *accountsv1al
 
 	res, err := a.fga.Check(ctx, &req)
 	if err != nil {
+		metrics.AuthorizationChecks.WithLabelValues("error").Inc()
 		return false, errors.Wrap(err, "failed to check permission with openfga")
+	}
+
+	if res.Allowed {
+		metrics.AuthorizationChecks.WithLabelValues("allowed").Inc()
+	} else {
+		metrics.AuthorizationChecks.WithLabelValues("denied").Inc()
 	}
 
 	return res.Allowed, nil

--- a/pkg/keycloak/service.go
+++ b/pkg/keycloak/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/coreos/go-oidc"
 	"github.com/platform-mesh/golang-commons/errors"
@@ -18,6 +19,7 @@ import (
 	appcontext "github.com/platform-mesh/iam-service/pkg/context"
 	"github.com/platform-mesh/iam-service/pkg/graph"
 	keycloakClient "github.com/platform-mesh/iam-service/pkg/keycloak/client"
+	"github.com/platform-mesh/iam-service/pkg/metrics"
 )
 
 // sanitizeEmail returns a sanitized version of the email for logging (first 3 chars + ***)
@@ -76,8 +78,14 @@ func New(ctx context.Context, cfg *config.ServiceConfig) (*Service, error) {
 }
 
 func (s *Service) UserByMail(ctx context.Context, userID string) (*graph.User, error) {
+	start := time.Now()
+	defer func() {
+		metrics.KeycloakDuration.WithLabelValues("user_by_mail").Observe(time.Since(start).Seconds())
+	}()
+
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("user_by_mail", "error").Inc()
 		return nil, errors.Wrap(err, "failed to get KCP user context")
 	}
 
@@ -93,6 +101,7 @@ func (s *Service) UserByMail(ctx context.Context, userID string) (*graph.User, e
 	// Cache miss - fetch from Keycloak
 	user, err := s.fetchUserFromKeycloak(ctx, realm, userID)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("user_by_mail", "error").Inc()
 		return nil, errors.Wrap(err, "failed to fetch user from Keycloak for email %s", userID)
 	}
 
@@ -101,14 +110,21 @@ func (s *Service) UserByMail(ctx context.Context, userID string) (*graph.User, e
 		s.userCache.Set(realm, userID, user)
 	}
 
+	metrics.KeycloakRequests.WithLabelValues("user_by_mail", "success").Inc()
 	return user, nil
 }
 
 func (s *Service) GetUsers(ctx context.Context) ([]*graph.User, error) {
 	log := logger.LoadLoggerFromContext(ctx)
 
+	start := time.Now()
+	defer func() {
+		metrics.KeycloakDuration.WithLabelValues("get_users").Observe(time.Since(start).Seconds())
+	}()
+
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("get_users", "error").Inc()
 		return nil, errors.Wrap(err, "failed to get KCP user context")
 	}
 
@@ -121,6 +137,7 @@ func (s *Service) GetUsers(ctx context.Context) ([]*graph.User, error) {
 	// Fetch all users with pagination and caching
 	users, err := s.fetchAllUsers(ctx, realm)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("get_users", "error").Inc()
 		return nil, errors.Wrap(err, "failed to fetch all users from Keycloak for realm %s", realm)
 	}
 
@@ -129,6 +146,7 @@ func (s *Service) GetUsers(ctx context.Context) ([]*graph.User, error) {
 		Str("realm", realm).
 		Msg("Successfully fetched all users from Keycloak")
 
+	metrics.KeycloakRequests.WithLabelValues("get_users", "success").Inc()
 	return users, nil
 }
 
@@ -183,12 +201,19 @@ func (s *Service) fetchUserFromKeycloak(ctx context.Context, realm, email string
 
 func (s *Service) GetUsersByEmails(ctx context.Context, emails []string) (map[string]*graph.User, error) {
 	log := logger.LoadLoggerFromContext(ctx)
+
+	start := time.Now()
+	defer func() {
+		metrics.KeycloakDuration.WithLabelValues("get_users_by_emails").Observe(time.Since(start).Seconds())
+	}()
+
 	if len(emails) == 0 {
 		return map[string]*graph.User{}, nil
 	}
 
 	kctx, err := appcontext.GetKCPContext(ctx)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("get_users_by_emails", "error").Inc()
 		return nil, errors.Wrap(err, "failed to get KCP user context")
 	}
 
@@ -222,6 +247,7 @@ func (s *Service) GetUsersByEmails(ctx context.Context, emails []string) (map[st
 	if len(missingEmails) > 0 {
 		fetchedUsers, err := s.fetchUsersInParallel(ctx, realm, missingEmails)
 		if err != nil {
+			metrics.KeycloakRequests.WithLabelValues("get_users_by_emails", "error").Inc()
 			return nil, errors.Wrap(err, "failed to fetch users in parallel for realm %s", realm)
 		}
 
@@ -242,6 +268,7 @@ func (s *Service) GetUsersByEmails(ctx context.Context, emails []string) (map[st
 		Int("api_calls", len(missingEmails)).
 		Msg("Completed user lookup with cache")
 
+	metrics.KeycloakRequests.WithLabelValues("get_users_by_emails", "success").Inc()
 	return result, nil
 }
 
@@ -409,6 +436,11 @@ func (s *Service) fetchUsersInParallel(ctx context.Context, realm string, emails
 // EnrichUserRoles enriches user roles with complete user information from Keycloak
 // Updates the UserRoles slice in-place with FirstName, LastName, and UserID from Keycloak
 func (s *Service) EnrichUserRoles(ctx context.Context, userRoles []*graph.UserRoles) error {
+	start := time.Now()
+	defer func() {
+		metrics.KeycloakDuration.WithLabelValues("enrich_user_roles").Observe(time.Since(start).Seconds())
+	}()
+
 	if len(userRoles) == 0 {
 		return nil
 	}
@@ -433,6 +465,7 @@ func (s *Service) EnrichUserRoles(ctx context.Context, userRoles []*graph.UserRo
 	// Batch call to get all users at once
 	userMap, err := s.GetUsersByEmails(ctx, emails)
 	if err != nil {
+		metrics.KeycloakRequests.WithLabelValues("enrich_user_roles", "error").Inc()
 		return errors.Wrap(err, "failed to get users by emails for enrichment")
 	}
 
@@ -449,5 +482,6 @@ func (s *Service) EnrichUserRoles(ctx context.Context, userRoles []*graph.UserRo
 		}
 	}
 
+	metrics.KeycloakRequests.WithLabelValues("enrich_user_roles", "success").Inc()
 	return nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// AuthorizationChecks counts OpenFGA permission checks by result (allowed/denied/error).
+	AuthorizationChecks = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "iam_authorization_checks_total",
+			Help: "Total number of OpenFGA authorization checks by result.",
+		},
+		[]string{"result"},
+	)
+
+	// AuthorizationDuration observes how long each OpenFGA check takes, labelled by permission.
+	AuthorizationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "iam_authorization_duration_seconds",
+			Help:    "Duration of OpenFGA authorization checks in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"permission"},
+	)
+
+	// GraphQLRequests counts incoming GraphQL operations by operation name and result.
+	GraphQLRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "iam_graphql_requests_total",
+			Help: "Total number of GraphQL operations by operation name and result.",
+		},
+		[]string{"operation", "result"},
+	)
+
+	// KeycloakRequests counts outgoing Keycloak API calls by operation and result.
+	KeycloakRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "iam_keycloak_requests_total",
+			Help: "Total number of Keycloak API calls by operation and result.",
+		},
+		[]string{"operation", "result"},
+	)
+
+	// KeycloakDuration observes how long each Keycloak API call takes, labelled by operation.
+	KeycloakDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "iam_keycloak_duration_seconds",
+			Help:    "Duration of Keycloak API calls in seconds.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"operation"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		AuthorizationChecks,
+		AuthorizationDuration,
+		GraphQLRequests,
+		KeycloakRequests,
+		KeycloakDuration,
+	)
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,74 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/platform-mesh/iam-service/pkg/metrics"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
+
+// TestAuthorizationChecks verifies that the AuthorizationChecks counter increments
+// correctly for each result label (allowed/denied/error).
+func (s *MetricsTestSuite) TestAuthorizationChecks() {
+	before := testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("allowed"))
+	metrics.AuthorizationChecks.WithLabelValues("allowed").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("allowed")))
+
+	before = testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("denied"))
+	metrics.AuthorizationChecks.WithLabelValues("denied").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("denied")))
+
+	before = testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("error"))
+	metrics.AuthorizationChecks.WithLabelValues("error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AuthorizationChecks.WithLabelValues("error")))
+}
+
+// TestAuthorizationDuration verifies that the AuthorizationDuration histogram records
+// observations per permission label.
+func (s *MetricsTestSuite) TestAuthorizationDuration() {
+	before := testutil.CollectAndCount(metrics.AuthorizationDuration)
+	metrics.AuthorizationDuration.WithLabelValues("read").Observe(0.05)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.AuthorizationDuration), before)
+}
+
+// TestGraphQLRequests verifies that the GraphQLRequests counter increments
+// correctly for each operation/result label combination.
+func (s *MetricsTestSuite) TestGraphQLRequests() {
+	before := testutil.ToFloat64(metrics.GraphQLRequests.WithLabelValues("Users", "success"))
+	metrics.GraphQLRequests.WithLabelValues("Users", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.GraphQLRequests.WithLabelValues("Users", "success")))
+
+	before = testutil.ToFloat64(metrics.GraphQLRequests.WithLabelValues("AssignRolesToUsers", "error"))
+	metrics.GraphQLRequests.WithLabelValues("AssignRolesToUsers", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.GraphQLRequests.WithLabelValues("AssignRolesToUsers", "error")))
+}
+
+// TestKeycloakRequests verifies that the KeycloakRequests counter increments
+// correctly for each operation/result label combination.
+func (s *MetricsTestSuite) TestKeycloakRequests() {
+	before := testutil.ToFloat64(metrics.KeycloakRequests.WithLabelValues("user_by_mail", "success"))
+	metrics.KeycloakRequests.WithLabelValues("user_by_mail", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.KeycloakRequests.WithLabelValues("user_by_mail", "success")))
+
+	before = testutil.ToFloat64(metrics.KeycloakRequests.WithLabelValues("get_users", "error"))
+	metrics.KeycloakRequests.WithLabelValues("get_users", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.KeycloakRequests.WithLabelValues("get_users", "error")))
+}
+
+// TestKeycloakDuration verifies that the KeycloakDuration histogram records
+// observations per operation label.
+func (s *MetricsTestSuite) TestKeycloakDuration() {
+	before := testutil.CollectAndCount(metrics.KeycloakDuration)
+	metrics.KeycloakDuration.WithLabelValues("get_users").Observe(0.12)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.KeycloakDuration), before)
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1,8 +1,10 @@
 package router
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/platform-mesh/iam-service/pkg/config"
 	"github.com/platform-mesh/iam-service/pkg/graph"
+	"github.com/platform-mesh/iam-service/pkg/metrics"
 )
 
 func CreateRouter(
@@ -42,6 +45,24 @@ func CreateRouter(
 	gqHandler.Use(extension.Introspection{})
 	gqHandler.Use(extension.AutomaticPersistedQuery{
 		Cache: lru.New[string](100),
+	})
+
+	gqHandler.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+		oc := graphql.GetOperationContext(ctx)
+		opName := oc.OperationName
+		if opName == "" {
+			opName = "unknown"
+		}
+		rh := next(ctx)
+		return func(ctx context.Context) *graphql.Response {
+			resp := rh(ctx)
+			result := "success"
+			if resp != nil && len(resp.Errors) > 0 {
+				result = "error"
+			}
+			metrics.GraphQLRequests.WithLabelValues(opName, result).Inc()
+			return resp
+		}
 	})
 
 	if commonCfg.IsLocal {


### PR DESCRIPTION
## **Description**

Adds a `pkg/metrics` package to iam-service and wires custom Prometheus
metrics across the three main integration points of the service.

## **Testing**
`go test ./pkg/metrics/... -v`