### PR TITLE
Add SBOM scanning with Trivy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,26 +14,26 @@ concurrency:
 
 jobs:
   lint:
-    uses: platform-mesh/.github/.github/workflows/job-golang-lint.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-golang-lint.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     with:
       useTask: true
 
   test:
-    uses: platform-mesh/.github/.github/workflows/job-golang-test-source.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-golang-test-source.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     secrets: inherit
     with:
       useTask: true
       useLocalCoverageConfig: true
 
   create-version:
-    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     secrets: inherit
     permissions:
       contents: write
 
   docker-build-push:
     needs: [create-version, lint, test]
-    uses: platform-mesh/.github/.github/workflows/job-docker-build-push.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-docker-build-push.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     secrets: inherit
     permissions:
       contents: write
@@ -46,7 +46,7 @@ jobs:
 
   update-version:
     needs: [create-version, docker-build-push]
-    uses: platform-mesh/.github/.github/workflows/job-chart-version-update.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-chart-version-update.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     secrets: inherit
     with:
       appVersion: ${{ needs.create-version.outputs.version }}
@@ -55,7 +55,7 @@ jobs:
 
   sbom:
     needs: [create-version, docker-build-push]
-    uses: platform-mesh/.github/.github/workflows/job-sbom.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-sbom.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     permissions:
       contents: read
       packages: read
@@ -64,7 +64,7 @@ jobs:
 
   image-ocm:
     needs: [create-version, docker-build-push, sbom]
-    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     secrets: inherit
     permissions:
       contents: read
@@ -74,3 +74,14 @@ jobs:
       appVersion: ${{ needs.create-version.outputs.version }}
       repoName: iam-service
       commit: ${{ github.sha }}
+
+  scan-sbom:
+    needs: [create-version, sbom]
+    uses: platform-mesh/.github/.github/workflows/job-trivy-sbom.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    with:
+      componentVersion: ${{ needs.create-version.outputs.version }}
+      


### PR DESCRIPTION
This PR adds SBOM scanning with Trivy to the release workflow. This job will take the latest SBOM, scan it for vulnerabilities in the code and the image, and upload all findings to the Security tab. From there, the `platform-mesh/security` team will be coordinating fixing issues that are found.

More information can be found in https://github.com/platform-mesh/backlog/issues/226