### PR TITLE
Make scan-sbom job dependent on image-ocm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       commit: ${{ github.sha }}
 
   scan-sbom:
-    needs: [create-version, sbom]
+    needs: [create-version, docker-build-push, sbom, image-ocm]
     uses: platform-mesh/.github/.github/workflows/job-trivy-sbom.yml@05d96c3fb19e6283463369b857449f9440aba7dd # main
     permissions:
       contents: read


### PR DESCRIPTION
The job is failing to resolve the image, I believe because `image-ocm` should first write the component before we attempt fetching it in `scan-sbom`.